### PR TITLE
Add metadata on VM creation for monitoring

### DIFF
--- a/modules/openstack/playbooks/vm_create.yml
+++ b/modules/openstack/playbooks/vm_create.yml
@@ -11,6 +11,9 @@
         flavor: "{{ flavor }}"
         network: "{{ network }}"
         security_groups: "{{ security_groups }}"
+        meta:
+          prometheus_io_scrape: true
+          prometheus_io_port: 9100
       register: server_info
 
     - name: Set attributes


### PR DESCRIPTION
This PR adds Prometheus-related metadata to the created VM so Prometheus can scrape metrics from the node exporter in the VM (if installed)