### PR TITLE
Fix ansible requirements install error

### DIFF
--- a/docker-local/requirements.yml
+++ b/docker-local/requirements.yml
@@ -1,5 +1,6 @@
 roles:
   # Install a roles from Ansible Galaxy.
   - src: geerlingguy.docker
-  - src: geerlingguy.pip,1.3.0
+  - src: geerlingguy.pip
+    version: 1.3.0
   - src: geerlingguy.repo-epel


### PR DESCRIPTION
Requirements.yml file in current state throws an error when invoked with `ansible-galaxy install -r docker-local/requirements.yml`. This commit should fix it.