### PR TITLE
Force install ansible roles

### DIFF
--- a/deploy_local.sh
+++ b/deploy_local.sh
@@ -39,7 +39,7 @@ fi
 
 echo
 echo "Installing required Ansible roles"
-ansible-galaxy install -r ./docker-local/requirements.yml
+ansible-galaxy install -r ./docker-local/requirements.yml --force
 
 export CURRENT_USER=$(whoami)
 


### PR DESCRIPTION
If ansible-roles are already installed, the script will not install them, even if the installed version is outdated. This should fix it.