### PR TITLE
Activate .venv if exists

### DIFF
--- a/deploy_local.sh
+++ b/deploy_local.sh
@@ -26,6 +26,9 @@ RESUME=${2:-"--clean-state"}
 # remove prefix --
 RESUME=${RESUME#"--"}
 
+# use .venv, if exists
+if [ -f .venv/bin/activate ]; then . .venv/bin/activate && echo "Using python from $(command -v python3)"; fi
+
 # check current opera and modules version
 OPERA_CURRENT_VERSION=$(pip3 show opera 2>/dev/null | grep Version | awk '{print $2}')
 IAC_MODULES_CURRENT_VERSION=$(cd docker-local/modules 2>/dev/null && git tag --points-at HEAD)

--- a/deploy_local.sh
+++ b/deploy_local.sh
@@ -27,7 +27,23 @@ RESUME=${2:-"--clean-state"}
 RESUME=${RESUME#"--"}
 
 # use .venv, if exists
-if [ -f .venv/bin/activate ]; then . .venv/bin/activate && echo "Using python from $(command -v python3)"; fi
+if [ -f .venv/bin/activate ]; then
+  echo
+  echo
+  read -rp "Python virtual environment found in .venv dir. Do you want to activate it? [Y/n] " ynvenv
+  if [ "$ynvenv" != "${ynvenv#[Yy]}" ]; then
+
+    echo "Activating .venv"
+    . .venv/bin/activate
+  else
+    echo "Abort."
+  fi
+
+  echo "Using python interpreter from $(command -v python3)"
+
+fi
+
+exit
 
 # check current opera and modules version
 OPERA_CURRENT_VERSION=$(pip3 show opera 2>/dev/null | grep Version | awk '{print $2}')


### PR DESCRIPTION
If python environment, activated in shell, that runs deploy_local.sh does not have correct prerequisites, the script will create a new virtual environment in `.venv` dir. Install procedure will be executed even in case if .venv already exists and is properly configured (it will be deleted and created freshly). This behaviour can lengthen subsequent deploy/undeploy jobs.

This upgrade will check if .venv exists and use it without reinstalling it if it is already configured properly.