### PR TITLE
Registry access

### DIFF
--- a/deploy_local.sh
+++ b/deploy_local.sh
@@ -4,7 +4,7 @@
 # Pinned versions
 
 OPERA_VERSION="0.6.2"
-IAC_MODULES_VERSION="3.0.2"
+IAC_MODULES_VERSION="3.1.0"
 
 ########################
 
@@ -39,7 +39,7 @@ if [ -f .venv/bin/activate ]; then
     echo "Abort."
   fi
 
-  echo "Using python interpreter from $(command -v python3)"
+  echo "Switched to python interpreter from $(command -v python3)"
 
 fi
 
@@ -126,6 +126,8 @@ if $APT_PKG_MISSING || $OPERA_NOT_INSTALLED || $OPERA_WRONG_VERSION || $ANSIBLE_
     echo "Installing xOpera"
     pip3 install --ignore-installed "opera==$OPERA_VERSION"
 
+    echo
+    echo "Switched to python interpreter from $(command -v python3)"
 
   else
     echo
@@ -183,6 +185,13 @@ echo
 echo
 echo "Running installation script as" "$CURRENT_USER"
 
+IP_ADDRESS=$(ip route get 1 | awk '{print $(NF-2);exit}')
+export IP_ADDRESS
+
+echo
+echo
+echo "Running installation script on ip address:" "$IP_ADDRESS"
+
 echo
 echo
 echo "These are basic minimal inputs. If more advanced inputs are required please edit /docker-local/input.yaml file manually."
@@ -231,6 +240,7 @@ unset SODALITE_GIT_TOKEN
 unset SODALITE_DB_USERNAME
 unset SODALITE_DB_PASSWORD
 unset SODALITE_EMAIL
+unset IP_ADDRESS
 
 
 # sudo is needed to ensure ansible will get user's password

--- a/deploy_openstack.sh
+++ b/deploy_openstack.sh
@@ -4,7 +4,7 @@
 # Pinned versions
 
 OPERA_VERSION="0.6.2"
-IAC_MODULES_VERSION="3.0.2"
+IAC_MODULES_VERSION="3.1.0"
 
 ########################
 
@@ -40,7 +40,7 @@ if [ -f .venv/bin/activate ]; then
     echo "Abort."
   fi
 
-  echo "Using python interpreter from $(command -v python3)"
+  echo "Switched to python interpreter from $(command -v python3)"
 
 fi
 
@@ -90,7 +90,7 @@ if $APT_PKG_MISSING || $OPERA_NOT_INSTALLED || $OPERA_WRONG_VERSION || $OPENSTAC
   if $OPERA_WRONG_VERSION && ! $OPERA_NOT_INSTALLED; then
     echo "    - xOpera is on version $OPERA_CURRENT_VERSION, but version $OPERA_VERSION is needed."
   fi
-  if $OPERA_NOT_INSTALLED; then
+  if $OPENSTACKSDK_NOT_INSTALLED; then
     echo "    - OpenstackSDK is not installed."
   fi
   if $ANSIBLE_WRONG_VERSION; then
@@ -131,6 +131,8 @@ if $APT_PKG_MISSING || $OPERA_NOT_INSTALLED || $OPERA_WRONG_VERSION || $OPENSTAC
     echo "Installing xOpera"
     pip3 install --ignore-installed "opera[openstack]==$OPERA_VERSION"
 
+    echo
+    echo "Switched to python interpreter from $(command -v python3)"
 
   else
     echo
@@ -210,9 +212,6 @@ export SODALITE_DB_PASSWORD=$PASSWORD_INPUT
 echo
 read -rp "Please enter token for SODALITE Gitlab repository: " TOKEN_INPUT
 export SODALITE_GIT_TOKEN=$TOKEN_INPUT
-echo
-read -rp "Please enter ip of target registry: " REGISTRY_INPUT
-export REGISTRY_IP=$REGISTRY_INPUT
 
 # prepare inputs
 envsubst <./openstack/input.yaml.tmpl >./openstack/input.yaml
@@ -239,7 +238,6 @@ else
 fi
 
 unset CURRENT_USER
-unset REGISTRY_IP
 unset SODALITE_GIT_TOKEN
 unset SODALITE_DB_USERNAME
 unset SODALITE_DB_PASSWORD

--- a/docker-local/input.yaml
+++ b/docker-local/input.yaml
@@ -1,4 +1,5 @@
 username: local-username
+local_ipv4_address: local-ip
 docker-network: sodalite
 dockerhub-user: 
 dockerhub-pass: 

--- a/docker-local/input.yaml.tmpl
+++ b/docker-local/input.yaml.tmpl
@@ -1,4 +1,5 @@
 username: $CURRENT_USER
+local_ipv4_address: $IP_ADDRESS
 docker-network: sodalite
 dockerhub-user: 
 dockerhub-pass: 
@@ -21,7 +22,7 @@ xopera_env:
   XOPERA_DATABASE_USER: $SODALITE_DB_USERNAME
   XOPERA_DATABASE_PASSWORD: $SODALITE_DB_PASSWORD
 image_builder_env:
-  REGISTRY_IP: registry
+  REGISTRY_IP: $IP_ADDRESS
 modak_api_env:
   MODAK_DATABASE_PASSWORD: $SODALITE_DB_PASSWORD
   MODAK_DATABASE_HOST: modak-db

--- a/docker-local/service.yaml
+++ b/docker-local/service.yaml
@@ -339,7 +339,7 @@ topology_template:
     image-builder-api:
       type: sodalite.nodes.DockerizedComponent
       properties:
-        image_name:  sodaliteh2020/image-builder-api:0.3.0
+        image_name:  sodaliteh2020/image-builder-api:0.3.1
         docker_network_name:  { get_property: [ SELF, network, name ] }
         # exposed_ports:  ['5000']
         env: { get_input: image_builder_env }

--- a/docker-local/service.yaml
+++ b/docker-local/service.yaml
@@ -29,9 +29,9 @@ topology_template:
 
   inputs:  
     username:  
-      type: string 
-    docker-registry-ip:  
-      type: string 
+      type: string
+    local_ipv4_address:
+      type: string
     docker-network: 
       type: string
     dockerhub-user:
@@ -98,16 +98,59 @@ topology_template:
         - host: sodalite-vm
         - dependency: docker-host
 
-    docker-registry-certificate:
+    # docker image registry
+    internal-registry-server-certs:
+      type: sodalite.nodes.RegistryServerCertificate
+      properties:
+        country_name:               { get_input: docker-registry-cert-country-name }
+        organization_name:          { get_input: docker-registry-cert-organization-name }
+        email_address:              { get_input: docker-registry-cert-email-address }
+        cert_ipv4_address:          { get_input: local_ipv4_address }
+        cert_path: "/home/registry/certs"
+        cert_files_prefix: registry
+        domain_name: "SODALITE platform stack Registry"
+      requirements:
+        - host: sodalite-vm
+        - dependency: docker-host
+
+    internal-registry-client-certificate:
       type: sodalite.nodes.RegistryCertificate
       properties:
-        registry_ip:        localhost
+        registry_ip:        { get_input: local_ipv4_address }
         country_name:       { get_input: docker-registry-cert-country-name }
         organization_name:  { get_input: docker-registry-cert-organization-name }
         email_address:      { get_input: docker-registry-cert-email-address }
       requirements:
         - host: sodalite-vm
         - dependency: docker-host
+
+    docker-registry-container:
+      type: sodalite.nodes.DockerizedComponent
+      properties:
+        alias: registry
+        image_name: library/registry:2
+        ports:
+          - "443:443"
+        #TODO get filenames from docker-registry-certificate, when opera enables intrinsic functions on all depths
+        ca_cert: "/certs/ca.crt"
+        client_cert: "/certs/registry.crt"
+        client_key: "/certs/registry.key"
+        etc_hosts:
+          registry.docker.local: 127.0.0.1
+        volumes:
+          - "/home/localregistry/registry:/var/lib/registry"
+          - "/home/registry/certs:/certs"
+        env:
+          REGISTRY_HTTP_ADDR: 0.0.0.0:443
+          REGISTRY_HTTP_TLS_CLIENTCAS: "[/certs/ca.crt]"
+          REGISTRY_HTTP_TLS_CERTIFICATE: "/certs/registry.crt"
+          REGISTRY_HTTP_TLS_KEY: "/certs/registry.key"
+        docker_network_name: { get_property: [ SELF, network, name ] }
+      requirements:
+        - host: docker-host
+        - registry: docker-public-registry
+        - network: docker-network
+        - dependency: internal-registry-server-certs
 
     traefik-tls-certs:
       type: sodalite.nodes.TLS.Certificate
@@ -237,7 +280,6 @@ topology_template:
         - host: docker-host
         - registry: docker-public-registry
         - network: docker-network
-        - dependency: docker-registry-certificate
         - dependency: xopera-openstack-keys
         - dependency: xopera-postgres
         - dependency: xopera-openapi-volume
@@ -272,35 +314,6 @@ topology_template:
         - network: docker-network
         - dependency: xopera-rest-api
         - dependency: xopera-openapi-volume
-
-    # image registry
-    docker-registry-container:
-      type: sodalite.nodes.DockerizedComponent
-      properties:
-        alias: registry
-        image_name: library/registry:2
-        ports:
-          - "443:443"
-        #TODO get filenames from docker-registry-certificate, when opera enables intrinsic functions on all depths
-        ca_cert: "/certs/ca.crt"
-        client_cert: "/certs/localhost.crt"
-        client_key: "/certs/localhost.key"
-        etc_hosts:
-          registry.docker.local: 127.0.0.1
-        volumes:
-          - "/home/localregistry/registry:/var/lib/registry"
-          - "/home/nginx/certs:/certs"
-        env:
-          REGISTRY_HTTP_ADDR: 0.0.0.0:443
-          REGISTRY_HTTP_TLS_CLIENTCAS: "[/certs/ca.crt]"
-          REGISTRY_HTTP_TLS_CERTIFICATE: "/certs/localhost.crt"
-          REGISTRY_HTTP_TLS_KEY: "/certs/localhost.key"
-        docker_network_name:  { get_property: [ SELF, network, name ] }  
-      requirements:
-        - host: docker-host
-        - registry: docker-public-registry   
-        - network: docker-network   
-        - dependency: docker-registry-certificate 
 
     # iac-blueprint-builder 
     # https://github.com/SODALITE-EU/iac-blueprint-builder 

--- a/docker-local/service.yaml
+++ b/docker-local/service.yaml
@@ -99,7 +99,7 @@ topology_template:
         - dependency: docker-host
 
     # docker image registry
-    internal-registry-server-certs:
+    docker-private-registry-server-certs:
       type: sodalite.nodes.RegistryServerCertificate
       properties:
         country_name:               { get_input: docker-registry-cert-country-name }
@@ -113,7 +113,7 @@ topology_template:
         - host: sodalite-vm
         - dependency: docker-host
 
-    internal-registry-client-certificate:
+    docker-private-registry-client-certificate:
       type: sodalite.nodes.RegistryCertificate
       properties:
         registry_ip:        { get_input: local_ipv4_address }
@@ -124,14 +124,14 @@ topology_template:
         - host: sodalite-vm
         - dependency: docker-host
 
-    docker-registry-container:
+    docker-private-registry:
       type: sodalite.nodes.DockerizedComponent
       properties:
         alias: registry
         image_name: library/registry:2
         ports:
           - "443:443"
-        #TODO get filenames from docker-registry-certificate, when opera enables intrinsic functions on all depths
+        #TODO get filenames from docker-registry-certificate, when opera enables functions on all depths
         ca_cert: "/certs/ca.crt"
         client_cert: "/certs/registry.crt"
         client_key: "/certs/registry.key"
@@ -150,7 +150,7 @@ topology_template:
         - host: docker-host
         - registry: docker-public-registry
         - network: docker-network
-        - dependency: internal-registry-server-certs
+        - dependency: docker-private-registry-server-certs
 
     traefik-tls-certs:
       type: sodalite.nodes.TLS.Certificate

--- a/library/config/artifacts/image-builder.env.tmpl
+++ b/library/config/artifacts/image-builder.env.tmpl
@@ -1,0 +1,1 @@
+REGISTRY_IP: {{ local_ipv4_address }}

--- a/library/env/artifacts/image-builder.env.tmpl
+++ b/library/env/artifacts/image-builder.env.tmpl
@@ -1,0 +1,1 @@
+REGISTRY_IP={{ public_ipv4_address }}

--- a/library/env/types.yaml
+++ b/library/env/types.yaml
@@ -1,0 +1,38 @@
+tosca_definitions_version: tosca_simple_yaml_1_3
+imports:
+  - ../../modules/misc/conf/types.yaml
+
+node_types:
+  sodalite.nodes.ImageBuilderEnv:
+    derived_from: sodalite.nodes.Configuration
+    properties:
+      template_name:
+        description: Filename of configuration template
+        required: True
+        type: string
+        default: "image-builder.env.tmpl"
+      public_ipv4_address:
+        description: Vm's ipv4 address
+        required: True
+        type: string
+    interfaces:
+      Standard:
+        type: tosca.interfaces.node.lifecycle.Standard
+        operations:
+          create:
+            inputs:
+              dir: { type: string, default: { get_property: [ SELF, dir ] } }
+              filename: { type: string, default: { get_property: [ SELF, filename ] } }
+              template_name: { type: string, default: { get_property: [ SELF, template_name ] } }
+              public_ipv4_address: { type: string, default: { get_property: [ SELF, public_ipv4_address ] } }
+              permissions: { type: string, default: { get_property: [ SELF, permissions ] } }
+            implementation:
+              primary: ../../modules/misc/conf/playbooks/create_conf.yml
+              dependencies:
+                - artifacts/image-builder.env.tmpl
+          delete:
+            inputs:
+              dir: { type: string, default: { get_property: [ SELF, dir ] } }
+              filename: { type: string, default: { get_property: [ SELF, filename ] } }
+            implementation:
+              primary: ../../modules/misc/conf/playbooks/remove_conf.yml

--- a/library/prometheus/playbooks/config_create.yml
+++ b/library/prometheus/playbooks/config_create.yml
@@ -6,6 +6,10 @@
       file:
         path: "{{ dest | dirname }}"
         state: directory
+    - name: Remove previous config
+      file:
+        path: "{{ dest }}"
+        state: absent
     - name: Create config file
       template:
         src: "prometheus.yaml.tmpl"

--- a/openstack/input.yaml
+++ b/openstack/input.yaml
@@ -1,4 +1,4 @@
-ssh-key-name: mihatr
+ssh-key-name: some_key
 image-name: "centos-7 x86_64"
 openstack-network-name: xlab
 flavor-name: m1.large
@@ -8,24 +8,24 @@ dockerhub-pass:
 docker-public-registry-url: registry.hub.docker.com
 docker-registry-cert-country-name: SI
 docker-registry-cert-organization-name: XLAB
-docker-registry-cert-email-address: aaaa
+docker-registry-cert-email-address: some_email@email.com
 postgres_env:
-  POSTGRES_USER: bbbb
-  POSTGRES_PASSWORD: ccc
+  POSTGRES_USER: username
+  POSTGRES_PASSWORD: password
   POSTGRES_DB: postgres
 xopera_env:
   XOPERA_GIT_TYPE: gitlab
   XOPERA_GIT_URL: https://gitlab.com
-  XOPERA_GIT_AUTH_TOKEN: YgK5Doxp2XyXG5dNhxwK
+  XOPERA_GIT_AUTH_TOKEN: some_token
   XOPERA_VERBOSE_MODE: debug
   XOPERA_DATABASE_IP: xopera-postgres
   XOPERA_DATABASE_NAME: postgres
-  XOPERA_DATABASE_USER: bbbb
-  XOPERA_DATABASE_PASSWORD: ccc
+  XOPERA_DATABASE_USER: username
+  XOPERA_DATABASE_PASSWORD: password
 modak_api_env:
-  MODAK_DATABASE_PASSWORD: ccc
+  MODAK_DATABASE_PASSWORD: password
   MODAK_DATABASE_HOST: modak-db
   MODAK_DATABASE_PORT: "3306"
 modak_db_env:
   MYSQL_ROOT_HOST: "%"
-  MYSQL_ROOT_PASSWORD: ccc
+  MYSQL_ROOT_PASSWORD: password

--- a/openstack/input.yaml
+++ b/openstack/input.yaml
@@ -1,4 +1,4 @@
-ssh-key-name: some_key
+ssh-key-name: mihatr
 image-name: "centos-7 x86_64"
 openstack-network-name: xlab
 flavor-name: m1.large
@@ -6,29 +6,26 @@ docker-network: sodalite
 dockerhub-user: 
 dockerhub-pass: 
 docker-public-registry-url: registry.hub.docker.com
-docker-private-registry-url: SODALITE_private_registry_url
 docker-registry-cert-country-name: SI
 docker-registry-cert-organization-name: XLAB
-docker-registry-cert-email-address: some_email@email.com
+docker-registry-cert-email-address: aaaa
 postgres_env:
-  POSTGRES_USER: username
-  POSTGRES_PASSWORD: password
+  POSTGRES_USER: bbbb
+  POSTGRES_PASSWORD: ccc
   POSTGRES_DB: postgres
 xopera_env:
   XOPERA_GIT_TYPE: gitlab
   XOPERA_GIT_URL: https://gitlab.com
-  XOPERA_GIT_AUTH_TOKEN: some_token
+  XOPERA_GIT_AUTH_TOKEN: YgK5Doxp2XyXG5dNhxwK
   XOPERA_VERBOSE_MODE: debug
   XOPERA_DATABASE_IP: xopera-postgres
   XOPERA_DATABASE_NAME: postgres
-  XOPERA_DATABASE_USER: username
-  XOPERA_DATABASE_PASSWORD: password
-image_builder_env:
-  REGISTRY_IP: SODALITE_private_registry_url
+  XOPERA_DATABASE_USER: bbbb
+  XOPERA_DATABASE_PASSWORD: ccc
 modak_api_env:
-  MODAK_DATABASE_PASSWORD: password
+  MODAK_DATABASE_PASSWORD: ccc
   MODAK_DATABASE_HOST: modak-db
   MODAK_DATABASE_PORT: "3306"
 modak_db_env:
   MYSQL_ROOT_HOST: "%"
-  MYSQL_ROOT_PASSWORD: password
+  MYSQL_ROOT_PASSWORD: ccc

--- a/openstack/input.yaml.tmpl
+++ b/openstack/input.yaml.tmpl
@@ -6,7 +6,6 @@ docker-network: sodalite
 dockerhub-user: 
 dockerhub-pass: 
 docker-public-registry-url: registry.hub.docker.com
-docker-private-registry-url: registry
 docker-registry-cert-country-name: SI
 docker-registry-cert-organization-name: XLAB
 docker-registry-cert-email-address: $SODALITE_EMAIL
@@ -23,8 +22,6 @@ xopera_env:
   XOPERA_DATABASE_NAME: postgres
   XOPERA_DATABASE_USER: $SODALITE_DB_USERNAME
   XOPERA_DATABASE_PASSWORD: $SODALITE_DB_PASSWORD
-image_builder_env:
-  REGISTRY_IP: registry
 modak_api_env:
   MODAK_DATABASE_PASSWORD: $SODALITE_DB_PASSWORD
   MODAK_DATABASE_HOST: modak-db

--- a/openstack/service.yaml
+++ b/openstack/service.yaml
@@ -12,13 +12,21 @@ imports:
   - modules/misc/tls/types.yaml
   - modules/tests/test_definitions.yaml
   - library/config/types.yaml
+  - library/env/types.yaml
   - library/prometheus/prometheus_config.yaml
+
+node_types:
+
+  sodalite.nodes.localhost-computer:
+    derived_from: tosca.nodes.Compute
+    properties:
+      name:
+        type: string
+        description: Name of machine. Used to write into registry certificate
 
 topology_template:
 
-  inputs:  
-    docker-registry-ip:  
-      type: string 
+  inputs:
     ssh-key-name:  
       type: string 
     image-name:  
@@ -38,9 +46,6 @@ topology_template:
     docker-public-registry-url: 
       type: string
       default: ""
-    docker-private-registry-url: 
-      type: string
-      default: ""
     docker-registry-cert-country-name:
       type: string
       default: ""
@@ -54,8 +59,6 @@ topology_template:
       type: map
     xopera_env:
       type: map
-    image_builder_env:
-      type: map  
     modak_api_env:
       type: map
     modak_db_env:
@@ -151,6 +154,14 @@ topology_template:
         - protected_by: security-rules-sodalite 
         - protected_by: security-rules-remote-access
 
+    local-computer:
+      type: sodalite.nodes.localhost-computer
+      properties:
+        name: localhost
+      attributes:
+        private_address: localhost
+        public_address: localhost
+
     docker-host:
       type: sodalite.nodes.DockerHost
       requirements:
@@ -161,7 +172,7 @@ topology_template:
       properties:  
         name: { get_input: docker-network }
       requirements:
-        - host: sodalite-vm 
+        - host: sodalite-vm
         - dependency: docker-host    
         
     docker-public-registry:
@@ -172,16 +183,71 @@ topology_template:
         - host: sodalite-vm
         - dependency: docker-host
 
-    docker-registry-certificate:
+    # docker image registry
+    docker-private-registry-server-certs:
+      type: sodalite.nodes.RegistryServerCertificate
+      properties:
+        country_name:               { get_input: docker-registry-cert-country-name }
+        organization_name:          { get_input: docker-registry-cert-organization-name }
+        email_address:              { get_input: docker-registry-cert-email-address }
+        cert_path: "/home/registry/certs"
+        cert_files_prefix: registry
+        domain_name: "SODALITE platform stack Registry"
+      requirements:
+        - host: sodalite-vm
+        - dependency: docker-host
+
+    # for registry access from within 'sodalite-vm'
+    docker-private-registry-internal-client-certificate:
       type: sodalite.nodes.RegistryCertificate
       properties:
-        registry_ip:        { get_input: docker-private-registry-url }
+        registry_ip:        { get_attribute: [ SELF, host, public_address ] }
         country_name:       { get_input: docker-registry-cert-country-name }
         organization_name:  { get_input: docker-registry-cert-organization-name }
         email_address:      { get_input: docker-registry-cert-email-address }
       requirements:
         - host: sodalite-vm
         - dependency: docker-host
+
+    # for registry access from deploying computer
+    docker-private-registry-localhost-client-certificate:
+      type: sodalite.nodes.RegistryCertificate
+      properties:
+        registry_ip: { get_attribute: [ SELF, dependency, public_address ] }
+        country_name: { get_input: docker-registry-cert-country-name }
+        organization_name: { get_input: docker-registry-cert-organization-name }
+        email_address: { get_input: docker-registry-cert-email-address }
+      requirements:
+        - host: local-computer
+        - dependency: sodalite-vm
+
+    docker-registry-container:
+      type: sodalite.nodes.DockerizedComponent
+      properties:
+        alias: registry
+        image_name: library/registry:2
+        ports:
+          - "443:443"
+        #TODO get filenames from docker-registry-certificate, when opera enables functions on all depths
+        ca_cert: "/certs/ca.crt"
+        client_cert: "/certs/registry.crt"
+        client_key: "/certs/registry.key"
+        etc_hosts:
+          registry.docker.local: 127.0.0.1
+        volumes:
+          - "/home/localregistry/registry:/var/lib/registry"
+          - "/home/registry/certs:/certs"
+        env:
+          REGISTRY_HTTP_ADDR: 0.0.0.0:443
+          REGISTRY_HTTP_TLS_CLIENTCAS: "[/certs/ca.crt]"
+          REGISTRY_HTTP_TLS_CERTIFICATE: "/certs/registry.crt"
+          REGISTRY_HTTP_TLS_KEY: "/certs/registry.key"
+        docker_network_name: { get_property: [ SELF, network, name ] }
+      requirements:
+        - host: docker-host
+        - registry: docker-public-registry
+        - network: docker-network
+        - dependency: docker-private-registry-server-certs
 
     traefik-tls-certs:
       type: sodalite.nodes.TLS.Certificate
@@ -311,7 +377,6 @@ topology_template:
         - host: docker-host
         - registry: docker-public-registry
         - network: docker-network
-        - dependency: docker-registry-certificate
         - dependency: xopera-openstack-keys
         - dependency: xopera-postgres
         - dependency: xopera-openapi-volume
@@ -347,35 +412,6 @@ topology_template:
         - dependency: xopera-rest-api
         - dependency: xopera-openapi-volume
 
-    # image registry
-    docker-registry-container:
-      type: sodalite.nodes.DockerizedComponent
-      properties:
-        alias: registry
-        image_name: library/registry:2
-        ports:
-          - "443:443"
-        #TODO get filenames from docker-registry-certificate, when opera enables intrinsic functions on all depths
-        ca_cert: "/certs/ca.crt"
-        client_cert: "/certs/localhost.crt"
-        client_key: "/certs/localhost.key"
-        etc_hosts:
-          registry.docker.local: 127.0.0.1
-        volumes:
-          - "/home/localregistry/registry:/var/lib/registry"
-          - "/home/nginx/certs:/certs"
-        env:
-          REGISTRY_HTTP_ADDR: 0.0.0.0:443
-          REGISTRY_HTTP_TLS_CLIENTCAS: "[/certs/ca.crt]"
-          REGISTRY_HTTP_TLS_CERTIFICATE: "/certs/localhost.crt"
-          REGISTRY_HTTP_TLS_KEY: "/certs/localhost.key"
-        docker_network_name:  { get_property: [ SELF, network, name ] }
-      requirements:
-        - host: docker-host
-        - registry: docker-public-registry   
-        - network: docker-network
-        - dependency: docker-registry-certificate
-
     # iac-blueprint-builder 
     # https://github.com/SODALITE-EU/iac-blueprint-builder 
     iac-builder-container:
@@ -396,14 +432,26 @@ topology_template:
         - dependency: proxy
 
     # image-builder     
-    # https://github.com/SODALITE-EU/image-builder  
+    # https://github.com/SODALITE-EU/image-builder
+    image-builder-env:
+      type: sodalite.nodes.ImageBuilderEnv
+      properties:
+        public_ipv4_address: { get_attribute: [ SELF, host, public_address ] }
+        dir: /tmp/image-builder/
+        filename: image-builder.env
+        template_name: image-builder.env.tmpl
+      requirements:
+        - host: sodalite-vm
+
     image-builder-api:
       type: sodalite.nodes.DockerizedComponent
       properties:
-        image_name:  sodaliteh2020/image-builder-api:0.3.0
+        image_name:  sodaliteh2020/image-builder-api:0.3.1
         docker_network_name:  { get_property: [ SELF, network, name ] }
-        # exposed_ports:  ['5000']
-        env: { get_input: image_builder_env }
+        env_file: /tmp/image-builder/image-builder.env
+        #TODO get REGISTRY_IP directly from host's public_address, when opera supports function evaluation on all depths
+#        env:
+#          REGISTRY_IP: { get_attribute: [ SELF, host_vm, public_address ] }
         volumes:
           - "/var/run/docker.sock:/var/run/docker.sock"
         alias: image-builder-api
@@ -416,9 +464,11 @@ topology_template:
           traefik.http.routers.image-builder.entrypoints: "image-builder"
           traefik.http.routers.image-builder.tls: "true"
       requirements:
+        - host_vm: sodalite-vm
         - host:  docker-host
         - registry: docker-public-registry 
         - network: docker-network
+        - dependency: image-builder-env
 
     # semantic-reasoner     
     # https://github.com/SODALITE-EU/semantic-reasoner 

--- a/openstack/service.yaml
+++ b/openstack/service.yaml
@@ -221,7 +221,7 @@ topology_template:
         - host: local-computer
         - dependency: sodalite-vm
 
-    docker-registry-container:
+    docker-private-registry:
       type: sodalite.nodes.DockerizedComponent
       properties:
         alias: registry


### PR DESCRIPTION
Features:
- Registry is accessible from withing sodalite stack
- When deploying to openstack, TOSCA service template installs registry client certs on localhost (to access registry on openstack)
- using new version of iac-modules (3.1.0)
- target internal registry with image-builder 



Closes #21 