### PR TITLE
Fix cryptography installation failure on ubuntu

### DIFF
--- a/deploy_local.sh
+++ b/deploy_local.sh
@@ -4,7 +4,7 @@
 # Pinned versions
 
 OPERA_VERSION="0.6.4"
-IAC_MODULES_VERSION="3.1.1"
+IAC_MODULES_VERSION="3.2.1"
 
 ########################
 

--- a/deploy_openstack.sh
+++ b/deploy_openstack.sh
@@ -4,7 +4,7 @@
 # Pinned versions
 
 OPERA_VERSION="0.6.4"
-IAC_MODULES_VERSION="3.1.1"
+IAC_MODULES_VERSION="3.2.1"
 
 ########################
 


### PR DESCRIPTION
Cryptography RUST dependency caused a lot of issues. We patched centos7 installation issues in #26 but failed to solve issues for other distributions. This PR introduces a new version of iac-modules ([3.2.1](https://github.com/SODALITE-EU/iac-modules/releases/tag/3.2.1)), which addressed this issue in SODALITE-EU/iac-modules#6.

Closes #28 