### PR TITLE
Gitlab token is not uuid

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ following guidelines:
 -   password should not have special characters
 -   [xOpera GIT config](https://github.com/SODALITE-EU/xopera-rest-api#git-backend-server-optional-recommended) 
 (url, token) should be real, otherwise xOpera REST API will not start. 
--   all tokens (SODALITE_GIT_TOKEN, VAULT_TOKEN, KEYCLOAK_CLIENT_SECRET) must comply with [UUID standard](https://tools.ietf.org/html/rfc4122)
+-   some inputs (VAULT_TOKEN, KEYCLOAK_CLIENT_SECRET) must comply with [UUID standard](https://tools.ietf.org/html/rfc4122)
 ### Alternative installation
 Preferred method for installation is use of [deploy_local.sh](deploy_local.sh) and [deploy_openstack.sh](deploy_openstack.sh). Alternatively, see [manuall install steps](manual_install.md).
 

--- a/deploy_local.sh
+++ b/deploy_local.sh
@@ -265,10 +265,7 @@ if [[ -z "$REUSE_INPUT_FILE" ]]; then
   export SODALITE_DB_PASSWORD=$PASSWORD_INPUT
 
   echo
-  read -rp "Please enter token (UUID) for SODALITE Gitlab repository: " TOKEN_INPUT
-  while [[ ! "$TOKEN_INPUT" =~ $UUID_pattern ]]; do
-    read -rp "\"$TOKEN_INPUT\" is not UUID. Please enter a valid UUID: " TOKEN_INPUT
-  done
+  read -rp "Please enter token for SODALITE Gitlab repository: " TOKEN_INPUT
   export SODALITE_GIT_TOKEN=$TOKEN_INPUT
 
   echo

--- a/deploy_openstack.sh
+++ b/deploy_openstack.sh
@@ -382,10 +382,7 @@ if [[ -z "$REUSE_INPUT_FILE" ]]; then
   export SODALITE_DB_PASSWORD=$PASSWORD_INPUT
 
   echo
-  read -rp "Please enter token (UUID) for SODALITE Gitlab repository: " TOKEN_INPUT
-  while [[ ! "$TOKEN_INPUT" =~ $UUID_pattern ]]; do
-    read -rp "\"$TOKEN_INPUT\" is not UUID. Please enter a valid UUID: " TOKEN_INPUT
-  done
+  read -rp "Please enter token for SODALITE Gitlab repository: " TOKEN_INPUT
   export SODALITE_GIT_TOKEN=$TOKEN_INPUT
 
   echo


### PR DESCRIPTION
#34 wrongly implemented UUID validation for SODALITE_GIT_TOKEN, which is not in UUID format.

This PR removes it.