### PR TITLE
Release M24Release version

### DIFF
--- a/docker-local/service.yaml
+++ b/docker-local/service.yaml
@@ -302,7 +302,7 @@ topology_template:
       properties:
         alias: pds
         docker_network_name:  { get_property: [ SELF, network, name ] }
-        image_name: sodaliteh2020/platform-discovery-service
+        image_name: sodaliteh2020/platform-discovery-service:M24Release
         restart_policy: always
         ports:  ['8089:8081']
         env: { get_input: pds_env }
@@ -350,7 +350,7 @@ topology_template:
       properties:
         alias: xopera-rest-api
         docker_network_name: { get_property: [ SELF, network, name ] }
-        image_name: sodaliteh2020/xopera-rest-api:2.4.0
+        image_name: sodaliteh2020/xopera-rest-api:M24Release
         restart_policy: always
         volumes:
           - /var/run/docker.sock:/var/run/docker.sock
@@ -430,7 +430,7 @@ topology_template:
     image-builder-api:
       type: sodalite.nodes.DockerizedComponent
       properties:
-        image_name:  sodaliteh2020/image-builder-api:1.0.0
+        image_name:  sodaliteh2020/image-builder-api:M24Release
         docker_network_name:  { get_property: [ SELF, network, name ] }
         env: { get_input: image_builder_env }
         volumes:
@@ -456,7 +456,7 @@ topology_template:
       properties:
         alias: graph-db
         docker_network_name:  { get_property: [ SELF, network, name ] }
-        image_name: sodaliteh2020/graph_db:192
+        image_name: sodaliteh2020/graph_db:M24Release
         restart_policy: always
         ports:  ['7200:7200']
         exposed_ports:  ['7200']
@@ -502,7 +502,7 @@ topology_template:
       type: sodalite.nodes.DockerizedComponent
       properties:
         alias: iac-metrics
-        image_name: sodaliteh2020/iacmetrics:8
+        image_name: sodaliteh2020/iacmetrics:M24Release
         restart_policy: always
         ports:  ['5003:5000']
       requirements:
@@ -516,7 +516,7 @@ topology_template:
       properties:
         alias: tosca-smells
         docker_network_name:  { get_property: [ SELF, network, name ] }
-        image_name: sodaliteh2020/toscasmells:349
+        image_name: sodaliteh2020/toscasmells:M24Release
         restart_policy: always
         env: { get_input: toscasmells_env }
         ports:  ['8082:8080']
@@ -531,7 +531,7 @@ topology_template:
       type: sodalite.nodes.DockerizedComponent
       properties:
         alias: ansible-smells
-        image_name: sodaliteh2020/ansiblesmells:349
+        image_name: sodaliteh2020/ansiblesmells:M24Release
         restart_policy: always
         ports:  ['5004:5000']
       requirements:
@@ -544,7 +544,7 @@ topology_template:
       type: sodalite.nodes.DockerizedComponent
       properties:
         alias: tosca-syntax
-        image_name: sodaliteh2020/toscasynverifier:8
+        image_name: sodaliteh2020/toscasynverifier:M24Release
         restart_policy: always
         ports:  ['5005:5000']
       requirements:
@@ -555,7 +555,7 @@ topology_template:
       type: sodalite.nodes.DockerizedComponent
       properties:
         alias: workflow-verifier
-        image_name: sodaliteh2020/workflowverifier:8
+        image_name: sodaliteh2020/workflowverifier:M24Release
         restart_policy: always
         ports:  ['5006:5000']
       requirements:
@@ -568,7 +568,7 @@ topology_template:
       type: sodalite.nodes.DockerizedComponent
       properties:
         alias: rule-based-refactorer
-        image_name: sodaliteh2020/rule_based_refactorer:49
+        image_name: sodaliteh2020/rule_based_refactorer:M24Release
         restart_policy: always
         ports:  ['8083:8080']
         docker_network_name:  { get_property: [ SELF, network, name ] }
@@ -589,7 +589,7 @@ topology_template:
       type: sodalite.nodes.DockerizedComponent
       properties:
         alias: performance-predictor-refactoring
-        image_name: sodaliteh2020/fo_perf_predictor_api:49
+        image_name: sodaliteh2020/fo_perf_predictor_api:M24Release
         restart_policy: always
         ports:  ['5007:5000']
         docker_network_name:  { get_property: [ SELF, network, name ] }
@@ -610,7 +610,7 @@ topology_template:
       type: sodalite.nodes.DockerizedComponent
       properties:
         alias: refactoring-option-discoverer
-        image_name: sodaliteh2020/refactoring_option_discoverer:60
+        image_name: sodaliteh2020/refactoring_option_discoverer:M24Release
         restart_policy: always
         ports:  ['8084:8080']
         env:
@@ -660,7 +660,7 @@ topology_template:
     prometheus-skydive-connector:
       type: sodalite.nodes.DockerizedComponent
       properties:
-        image_name: sodaliteh2020/prometheus-skydive-connector:1
+        image_name: sodaliteh2020/prometheus-skydive-connector:M24Release
         command: /etc/prom_sky_con.yml
         docker_network_name:  { get_property: [ SELF, network, name ] }
         env:
@@ -749,7 +749,7 @@ topology_template:
     monitoring-system-ruleserver:
       type: sodalite.nodes.DockerizedComponent
       properties:
-        image_name: sodaliteh2020/monitoring-system-ruleserver:0.2.0
+        image_name: sodaliteh2020/monitoring-system-ruleserver:M24Release
         restart_policy: always
         ports: [ '9092:9092' ]
         exposed_ports: [ '9092' ]
@@ -773,7 +773,7 @@ topology_template:
       type: sodalite.nodes.DockerizedComponent
       properties:
         alias: modak-api
-        image_name: sodaliteh2020/modak-api:0.1.2-dev
+        image_name: sodaliteh2020/modak-api:M24Release
         restart_policy: always
         ports:  ['55000:5000']
         exposed_ports:  ['55000']
@@ -789,7 +789,7 @@ topology_template:
       type: sodalite.nodes.DockerizedComponent
       properties:
         alias: modak-db
-        image_name: sodaliteh2020/modak-py3-mysql:0.1.2-dev
+        image_name: sodaliteh2020/modak-py3-mysql:M24Release
         restart_policy: always
         ports:  ['32000:3306']
         exposed_ports:  ['32000']

--- a/openstack/service.yaml
+++ b/openstack/service.yaml
@@ -419,7 +419,7 @@ topology_template:
       properties:
         alias: pds
         docker_network_name:  { get_property: [ SELF, network, name ] }
-        image_name: sodaliteh2020/platform-discovery-service
+        image_name: sodaliteh2020/platform-discovery-service:M24Release
         restart_policy: always
         ports:  ['8089:8081']
         env: { get_input: pds_env }
@@ -467,7 +467,7 @@ topology_template:
       properties:
         alias: xopera-rest-api
         docker_network_name: { get_property: [ SELF, network, name ] }
-        image_name: sodaliteh2020/xopera-rest-api:2.4.0
+        image_name: sodaliteh2020/xopera-rest-api:M24Release
         restart_policy: always
         volumes:
           - /var/run/docker.sock:/var/run/docker.sock
@@ -557,7 +557,7 @@ topology_template:
     image-builder-api:
       type: sodalite.nodes.DockerizedComponent
       properties:
-        image_name:  sodaliteh2020/image-builder-api:1.0.0
+        image_name:  sodaliteh2020/image-builder-api:M24Release
         docker_network_name:  { get_property: [ SELF, network, name ] }
         env_file: /tmp/image-builder/image-builder.env
         #TODO get REGISTRY_IP directly from host's public_address, when opera supports function evaluation on all depths
@@ -588,7 +588,7 @@ topology_template:
       properties:
         alias: graph-db
         docker_network_name:  { get_property: [ SELF, network, name ] }
-        image_name: sodaliteh2020/graph_db:192
+        image_name: sodaliteh2020/graph_db:M24Release
         restart_policy: always
         ports:  ['7200:7200']
         exposed_ports:  ['7200']
@@ -634,7 +634,7 @@ topology_template:
       type: sodalite.nodes.DockerizedComponent
       properties:
         alias: iac-metrics
-        image_name: sodaliteh2020/iacmetrics:8
+        image_name: sodaliteh2020/iacmetrics:M24Release
         restart_policy: always
         ports:  ['5003:5000']
       requirements:
@@ -648,7 +648,7 @@ topology_template:
       properties:
         alias: tosca-smells
         docker_network_name:  { get_property: [ SELF, network, name ] }
-        image_name: sodaliteh2020/toscasmells:349
+        image_name: sodaliteh2020/toscasmells:M24Release
         restart_policy: always
         env: { get_input: toscasmells_env }
         ports:  ['8082:8080']
@@ -663,7 +663,7 @@ topology_template:
       type: sodalite.nodes.DockerizedComponent
       properties:
         alias: ansible-smells
-        image_name: sodaliteh2020/ansiblesmells:349
+        image_name: sodaliteh2020/ansiblesmells:M24Release
         restart_policy: always
         ports:  ['5004:5000']
       requirements:
@@ -676,7 +676,7 @@ topology_template:
       type: sodalite.nodes.DockerizedComponent
       properties:
         alias: tosca-syntax
-        image_name: sodaliteh2020/toscasynverifier:8
+        image_name: sodaliteh2020/toscasynverifier:M24Release
         restart_policy: always
         ports:  ['5005:5000']
       requirements:
@@ -687,7 +687,7 @@ topology_template:
       type: sodalite.nodes.DockerizedComponent
       properties:
         alias: workflow-verifier
-        image_name: sodaliteh2020/workflowverifier:8
+        image_name: sodaliteh2020/workflowverifier:M24Release
         restart_policy: always
         ports:  ['5006:5000']
       requirements:
@@ -700,7 +700,7 @@ topology_template:
       type: sodalite.nodes.DockerizedComponent
       properties:
         alias: rule-based-refactorer
-        image_name: sodaliteh2020/rule_based_refactorer:49
+        image_name: sodaliteh2020/rule_based_refactorer:M24Release
         restart_policy: always
         ports:  ['8083:8080']
         docker_network_name:  { get_property: [ SELF, network, name ] }
@@ -721,7 +721,7 @@ topology_template:
       type: sodalite.nodes.DockerizedComponent
       properties:
         alias: performance-predictor-refactoring
-        image_name: sodaliteh2020/fo_perf_predictor_api:49
+        image_name: sodaliteh2020/fo_perf_predictor_api:M24Release
         restart_policy: always
         ports:  ['5007:5000']
         docker_network_name:  { get_property: [ SELF, network, name ] }
@@ -742,7 +742,7 @@ topology_template:
       type: sodalite.nodes.DockerizedComponent
       properties:
         alias: refactoring-option-discoverer
-        image_name: sodaliteh2020/refactoring_option_discoverer:60
+        image_name: sodaliteh2020/refactoring_option_discoverer:M24Release
         restart_policy: always
         ports:  ['8084:8080']
         env:
@@ -792,7 +792,7 @@ topology_template:
     prometheus-skydive-connector:
       type: sodalite.nodes.DockerizedComponent
       properties:
-        image_name: sodaliteh2020/prometheus-skydive-connector:1
+        image_name: sodaliteh2020/prometheus-skydive-connector:M24Release
         command: /etc/prom_sky_con.yml
         docker_network_name:  { get_property: [ SELF, network, name ] }
         env:
@@ -881,7 +881,7 @@ topology_template:
     monitoring-system-ruleserver:
       type: sodalite.nodes.DockerizedComponent
       properties:
-        image_name: sodaliteh2020/monitoring-system-ruleserver:0.2.0
+        image_name: sodaliteh2020/monitoring-system-ruleserver:M24Release
         restart_policy: always
         ports: [ '9092:9092' ]
         exposed_ports: [ '9092' ]
@@ -905,7 +905,7 @@ topology_template:
       type: sodalite.nodes.DockerizedComponent
       properties:
         alias: modak-api
-        image_name: sodaliteh2020/modak-api:0.1.2-dev
+        image_name: sodaliteh2020/modak-api:M24Release
         restart_policy: always
         ports:  ['55000:5000']
         exposed_ports:  ['55000']
@@ -921,7 +921,7 @@ topology_template:
       type: sodalite.nodes.DockerizedComponent
       properties:
         alias: modak-db
-        image_name: sodaliteh2020/modak-py3-mysql:0.1.2-dev
+        image_name: sodaliteh2020/modak-py3-mysql:M24Release
         restart_policy: always
         ports:  ['32000:3306']
         exposed_ports:  ['32000']


### PR DESCRIPTION
# The issue
The idea of `M12Release`, `M18Release` and `M24Release` versions is to pin the exact state of the SODALITE platform at that particulate milestone. Unfortunately, `M24Release` was pinned to repository-state with old platform stack, since most of the components inside blueprints were pinned to older versions.

# Solution
This Pull Request pins all SODALITE docker components to `M24Release`. Where `M24Release` was not present on dockerhub, I took last version, released before 1 Mar 2021, and retagged it as `M24Release`. Here is the list of [SODALITE components](https://hub.docker.com/u/sodaliteh2020) that did not have M24Release tag and their respective versions I took as basis for retagging to `M24Release`:

- sodaliteh2020/graph_db:192
- sodaliteh2020/iacmetrics:17
- sodaliteh2020/toscasmells:349
- sodaliteh2020/ansiblesmells:349
- sodaliteh2020/toscasynverifier:47
- sodaliteh2020/workflowverifier:47
- sodaliteh2020/rule_based_refactorer:90
- sodaliteh2020/fo_perf_predictor_api:90
- sodaliteh2020/refactoring_option_discoverer:116
- sodaliteh2020/prometheus-skydive-connector:1
- sodaliteh2020/monitoring-system-ruleserver:0.2.0
- sodaliteh2020/modak-api:0.1.2-dev
- sodaliteh2020/modak-py3-mysql:0.1.2-dev

# What needs to be done
After both blueprints from this PR are properly tested (@alexmaslenn can you do it? I don't know what all the components should do) we should merge it and move M24Release tag in this repo to this merge commit. Right after that, we should repin components to the most recent versions (this step would finally close issue #33). I see two options here:
- set docker-image-tags to `latest`
- pin docker-image-tags to the currently most recent version

IMO we should always use and test with `latest` components (and pin them on every iac-platform-stack release), but this implies every `latest` image on docker hub is considered to be  **production-ready**. I don't know if this is the case for all components. If it is not, maybe a better idea would be a hybrid approach, `latest` tag for stable components (xopera-rest-api, image-builder, ...) and last stable tag for unstable ones.

What do you think? @dradX @alexmaslenn?



